### PR TITLE
Remove notes menu and restore default heading sizes

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -359,9 +359,6 @@
   --font-paragraph: 'Source Sans';
   --font-mono: 'JetBrains Mono';
 
-  --h1-font-size: 1.5em;
-  --h2-font-size: 1.3em;
-  --hx-font-size: 1.1em;
   --p-font-size: 1em;
   --p-line-height: 1.5em;
   --caption-font-size: .8em;

--- a/content/posts/self-studying mathematics/index.md
+++ b/content/posts/self-studying mathematics/index.md
@@ -1,5 +1,7 @@
-# Self-studying mathematics
-#math
+---
+title: "Self-studying mathematics"
+tags: ["math"]
+---
 
 I'm starting this blog as a way to document progress on a long-standing goal of mine — teaching myself mathematics (with a bit of physics/CS too). I've been wanting to do this ever since I joined a theoretical neuroscience lab in my bachelor's, but for a long time I was a) afraid of failure and b) dealing with some chronic health issues, which have been (mostly) resolved now.
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -82,10 +82,6 @@ name = "posts"
 url = "/posts"
 
 [[params.menu]]
-name = "notes"
-url = "/notes"
-
-[[params.menu]]
 name = "publications"
 url = "/publications"
 

--- a/layouts/_default/publications.html
+++ b/layouts/_default/publications.html
@@ -16,7 +16,7 @@
         <div class="publication-entry">
             <div>
             <div class="publication-date">{{ .year }}</div>
-            <div class="publication-citations" data-doi="{{ .url }}">Loading...</div>
+            <div class="publication-citations" data-doi="{{ .url }}"></div>
             <img src="{{ .thumbnail }}" alt="Thumbnail for {{ .title }}">
             </div>
             


### PR DESCRIPTION
- Remove notes menu entry from hugo.toml
- Restore default heading font sizes in custom.css
- Fix YAML frontmatter in self-studying mathematics post
- Remove defunct 'Loading...' text from publications template