### PR TITLE
Remove images from publications page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -148,12 +148,24 @@
 /* Publication styles */
 /* Ensure publications inherit the main-content and content-wrapper styles */
 
+.publication-year-heading {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.9);
+    margin-top: 3rem;
+    margin-bottom: 2rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.publication-year-heading:first-of-type {
+    margin-top: 1rem;
+}
+
 .publication-entry {
-    display: grid;
-    grid-template-columns: 200px 1fr;
-    gap: 2.5rem;
-    margin-bottom: 4rem;
-    padding-bottom: 3rem;
+    display: block;
+    margin-bottom: 3rem;
+    padding-bottom: 2.5rem;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
     position: relative;
     width: 100%;
@@ -164,42 +176,13 @@
   padding-bottom: 0;
 }
 
-/* Left column styling */
-.publication-entry > div:first-child {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.publication-entry > div:first-child img {
-  width: 100%;
-  height: auto;
-  border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  order: 3; /* Place thumbnail at the bottom */
-}
-
-.publication-entry > div:first-child img:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
-
-.publication-date {
-    font-size: 1.75rem;
-    font-weight: 600;
-    color: rgba(255, 255, 255, 0.9);
-    order: 1;
-}
-
 .publication-citations {
     font-size: 0.9rem;
     color: rgba(255, 255, 255, 0.5);
-    order: 2;
+    margin-bottom: 0.75rem;
 }
 
-/* Right column styling */
+/* Main content styling */
 .publication-title {
     position: relative;
     text-decoration: none;
@@ -331,33 +314,15 @@
 
 /* Responsive design for publications */
 @media screen and (max-width: 768px) {
+  .publication-year-heading {
+    font-size: 2rem;
+    margin-top: 2rem;
+    margin-bottom: 1.5rem;
+  }
+
   .publication-entry {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-    margin-bottom: 3rem;
+    margin-bottom: 2rem;
     padding-bottom: 2rem;
-  }
-
-  .publication-entry > div:first-child {
-    flex-direction: row;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .publication-entry > div:first-child img {
-    width: 120px;
-    height: auto;
-    order: 1;
-    flex-shrink: 0;
-  }
-
-  .publication-date {
-    font-size: 1.5rem;
-    order: 2;
-  }
-
-  .publication-citations {
-    order: 3;
   }
 
   .publication-title {

--- a/layouts/_default/publications.html
+++ b/layouts/_default/publications.html
@@ -12,15 +12,34 @@
         <h1 class="single-title">{{ .Title }}</h1>
       </div>
       <div class="single-content">
-        {{ range .Params.publications }}
-        <div class="publication-entry">
-            <div>
-            <div class="publication-date">{{ .year }}</div>
+        {{ $publications := .Params.publications }}
+        {{ $groupedByYear := dict }}
+
+        {{/* Group publications by year */}}
+        {{ range $publications }}
+          {{ $yearStr := printf "%v" .year }}
+          {{ $existing := index $groupedByYear $yearStr | default slice }}
+          {{ $groupedByYear = merge $groupedByYear (dict $yearStr ($existing | append .)) }}
+        {{ end }}
+
+        {{/* Sort years in descending order */}}
+        {{ $years := slice }}
+        {{ range $year, $pubs := $groupedByYear }}
+          {{ $years = $years | append $year }}
+        {{ end }}
+        {{ $years = sort $years }}
+        {{ $years = $years | reverse }}
+
+        {{/* Display publications grouped by year */}}
+        {{ range $years }}
+          {{ $year := . }}
+          {{ $pubs := index $groupedByYear $year }}
+
+          <h2 class="publication-year-heading">{{ $year }}</h2>
+
+          {{ range $pubs }}
+          <div class="publication-entry">
             <div class="publication-citations" data-doi="{{ .url }}"></div>
-            <img src="{{ .thumbnail }}" alt="Thumbnail for {{ .title }}">
-            </div>
-            
-            <div>
             <a href="{{ .url }}" class="publication-title">{{ .title }}</a>
             <div class="publication-meta">
                 <div class="author">{{ .author }}</div>
@@ -37,8 +56,8 @@
               {{ end }}
             </div>
             {{ end }}
-            </div>
-        </div>
+          </div>
+          {{ end }}
         {{ end }}
 
         <!-- Load the citations script -->


### PR DESCRIPTION
- Remove images from publication entries
- Change layout from two-column grid to single-column full-width
- Group publications by year with year as a heading (appears once per year)
- Update responsive styles for mobile view
- Simplify publication entry structure