### PR TITLE
Enable LaTeX rendering in home bio section

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,7 +31,7 @@
     {{ partial "footer.html" . }}
   </footer>
 
-  {{ if .Param "math" }}
+  {{ if or (.Param "math") .IsHome }}
   {{ partialCached "math.html" . }}
   {{ end }}
 </body>


### PR DESCRIPTION
Modified baseof.html to include KaTeX rendering on the home page. This allows LaTeX expressions in the homeIntroContent parameter to be properly rendered using $ and $$ delimiters.