### PR TITLE
Add photos page with masonry-style grid layout

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -488,3 +488,164 @@ a.wikilink.broken:hover {
     margin: 0.3rem 0 0 1rem;
     color: var(--content-secondary);
 }
+
+/* ============================================
+   Photo Grid / Masonry Layout
+   ============================================
+   Usage: Add layout = "photos" to page front matter
+   - Images on the same line become columns in a row
+   - A blank line between images creates a new row
+   - Text width defaults to normal content width
+   - Image rows are full width by default
+
+   Inspired by Kepano's obsidian-minimal-publish
+   https://github.com/kepano/obsidian-minimal-publish
+*/
+
+:root {
+    /* Photo grid configuration */
+    --photos-grid-gap: 0.5rem;
+    --photos-img-fit: cover;
+    --photos-img-background: transparent;
+    --photos-max-width: 100vw;
+    --photos-margin-inline: calc((100vw - var(--main-width)) / -2 - var(--main-padding));
+    --photos-text-width: var(--main-width);
+}
+
+/* Container for photos layout pages */
+.photos-layout {
+    overflow-x: hidden;
+}
+
+/*
+   Multi-image rows: paragraphs containing consecutive figures
+   Uses :has() with sibling combinator to detect multiple images
+*/
+.photos-layout p:has(> figure ~ figure) {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+    grid-column-gap: var(--photos-grid-gap);
+    grid-row-gap: 0;
+    margin-block: var(--photos-grid-gap);
+    width: var(--photos-max-width);
+    max-width: var(--photos-max-width);
+    margin-inline: var(--photos-margin-inline);
+}
+
+/* Figures in multi-image rows */
+.photos-layout p:has(> figure ~ figure) figure {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.photos-layout p:has(> figure ~ figure) figure .img-container {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    aspect-ratio: unset;
+}
+
+.photos-layout p:has(> figure ~ figure) figure img {
+    width: 100%;
+    height: 100%;
+    object-fit: var(--photos-img-fit);
+    background: var(--photos-img-background);
+}
+
+/* Hide captions in multi-image rows */
+.photos-layout p:has(> figure ~ figure) figcaption {
+    display: none;
+}
+
+/*
+   Single image rows: also go full width
+*/
+.photos-layout p:has(> figure:only-child) {
+    width: var(--photos-max-width);
+    max-width: var(--photos-max-width);
+    margin-inline: var(--photos-margin-inline);
+    margin-block: var(--photos-grid-gap);
+}
+
+.photos-layout p:has(> figure:only-child) figure {
+    margin: 0;
+    width: 100%;
+}
+
+.photos-layout p:has(> figure:only-child) figure .img-container {
+    max-height: 80vh;
+    width: 100%;
+}
+
+.photos-layout p:has(> figure:only-child) figure img {
+    width: 100%;
+    height: auto;
+    max-height: 80vh;
+    object-fit: var(--photos-img-fit);
+}
+
+/*
+   Text content stays at normal width
+*/
+.photos-layout h1,
+.photos-layout h2,
+.photos-layout h3,
+.photos-layout h4,
+.photos-layout h5,
+.photos-layout h6,
+.photos-layout p:not(:has(figure)),
+.photos-layout ul,
+.photos-layout ol,
+.photos-layout blockquote,
+.photos-layout pre,
+.photos-layout hr,
+.photos-layout .single-intro-container {
+    max-width: var(--photos-text-width);
+}
+
+/* Responsive adjustments */
+@media screen and (max-width: 1024px) {
+    :root {
+        --photos-margin-inline: calc(-1 * var(--main-padding));
+    }
+}
+
+@media screen and (max-width: 640px) {
+    :root {
+        --photos-grid-gap: 0.25rem;
+    }
+}
+
+/* ============================================
+   Modifier classes for photos pages
+   ============================================ */
+
+/* Contained width (not full bleed) */
+.photos-contained {
+    --photos-max-width: 100%;
+    --photos-margin-inline: 0;
+}
+
+/* Different gap sizes */
+.photos-gap-none {
+    --photos-grid-gap: 0;
+}
+
+.photos-gap-sm {
+    --photos-grid-gap: 0.25rem;
+}
+
+.photos-gap-md {
+    --photos-grid-gap: 0.5rem;
+}
+
+.photos-gap-lg {
+    --photos-grid-gap: 1rem;
+}
+
+/* Image fit options */
+.photos-contain {
+    --photos-img-fit: contain;
+    --photos-img-background: var(--code-background);
+}

--- a/content/photos/index.md
+++ b/content/photos/index.md
@@ -1,0 +1,12 @@
++++
+title = "Photos"
+layout = "photos"
+hidePagination = true
+hideBackToTop = false
+# photosWidth = "contained"  # Keep images within normal content width instead of full-bleed
+# photosGap = "lg"           # Options: none, sm, md, lg (default: md = 0.5rem)
+# photosFit = "contain"      # Show full image instead of cropping to fill
++++
+
+A collection of photographs and images.
+

--- a/layouts/_default/photos.html
+++ b/layouts/_default/photos.html
@@ -1,0 +1,119 @@
+{{ define "main" }}
+
+{{/* Breadcrumbs */}}
+{{ if not .IsHome }}
+{{ partial "breadcrumbs.html" . }}
+{{ end }}
+
+{{/* Build class string for photos layout */}}
+{{ $classes := "photos-layout" }}
+{{ with .Param "photosWidth" }}
+  {{ if eq . "contained" }}
+    {{ $classes = printf "%s photos-contained" $classes }}
+  {{ end }}
+{{ end }}
+{{ with .Param "photosGap" }}
+  {{ if eq . "none" }}
+    {{ $classes = printf "%s photos-gap-none" $classes }}
+  {{ else if eq . "sm" }}
+    {{ $classes = printf "%s photos-gap-sm" $classes }}
+  {{ else if eq . "md" }}
+    {{ $classes = printf "%s photos-gap-md" $classes }}
+  {{ else if eq . "lg" }}
+    {{ $classes = printf "%s photos-gap-lg" $classes }}
+  {{ end }}
+{{ end }}
+{{ with .Param "photosFit" }}
+  {{ if eq . "contain" }}
+    {{ $classes = printf "%s photos-contain" $classes }}
+  {{ end }}
+{{ end }}
+
+<div class="{{ $classes }}" {{ if .Param "autonumber" }} class="autonumber" {{ end }}{{ if .Param "math" }} data-math="true"{{ end }}>
+
+  {{/* Main content container */}}
+  <div class="content-wrapper">
+    {{/* Table of Content with pure CSS positioning */}}
+    {{ if .Param "toc" }}
+    <aside class="toc css-sticky-toc">
+      <div class="toc-container">
+        <p><strong>Table of contents</strong></p>
+        {{ .TableOfContents }}
+      </div>
+    </aside>
+    {{ end }}
+
+    {{/* Content goes in its own container */}}
+    <div class="main-content">
+      <div class="single-intro-container">
+        {{/* Title and Summary */}}
+        <h1 class="single-title">{{ .Title }}</h1>
+        {{ with .Param "summary" }}
+        <p class="single-summary">{{ . | markdownify }}</p>
+        {{ end }}
+
+        {{ if .Store.Get "hasMermaid" }}
+        {{ $mermaidDarkTheme := default "dark" (or .Params.mermaidDarkTheme .Site.Params.mermaidDarkTheme) }}
+        {{ $mermaidTheme := default "default" (or .Params.mermaidTheme .Site.Params.mermaidTheme) }}
+        <script defer
+          type="module"
+          id="mermaid_script"
+          data-light-theme="{{ $mermaidTheme }}"
+          data-dark-theme="{{ $mermaidDarkTheme }}"
+          src='{{ "js/mermaid.js" | relURL }}'>
+        </script>
+        {{ end }}
+
+        {{/* Reading Time - optional for photos pages */}}
+        {{ if .Param "showDate" }}
+        <p class="single-readtime">
+          {{ with .Date }}
+          {{ $dateMachine := . | time.Format "2006-01-02T15:04:05-07:00" }}
+          {{ $dateHuman := . | time.Format (default ":date_long" $.Site.Params.singleDateFormat) }}
+          <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+          {{end}}
+        </p>
+        {{ end }}
+      </div>
+
+      {{ if .Param "showTags" }}
+      {{ $taxonomy := "tags" }}
+      {{ with .Param $taxonomy }}
+      <div class="single-tags">
+        {{ range $index, $tag := . }}
+        {{ with $.Site.GetPage (printf "/%s/%s" $taxonomy $tag) -}}
+        <span>
+          <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>
+        </span>
+        {{ end }}
+        {{ end }}
+      </div>
+      {{ end }}
+      {{ end }}
+
+      {{/* Page content */}}
+      <div class="single-content">
+        {{/* Process content through wikilinks partial */}}
+        {{ $processedContent := partial "wikilinks.html" .Content }}
+        {{ $processedContent | safeHTML }}
+
+        {{ if .Site.Params.giscus.enable }}
+        {{ if not .Params.disableComment }}
+        {{ partial "comments.html" . }}
+        {{ end }}
+        {{ end }}
+      </div>
+
+      {{/* Back to top */}}
+      {{ if not (.Param "hideBackToTop") }}
+      <div class="back-to-top">
+        <a href="#top">
+          back to top
+        </a>
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</div>
+
+{{ end }}


### PR DESCRIPTION
Adds a new /photos page with CSS-based masonry grid for images:
- Images on the same line become columns in a row
- Blank lines between images create new rows
- Full-width images by default, text stays at normal width
- Configurable margins, gaps, and object-fit via front matter

Inspired by Kepano's obsidian-minimal-publish implementation using CSS :has() selectors for detection.

https://claude.ai/code/session_01WJkbf5yhgzMURUtE4T5o5E