### PR TITLE
Make body typography consistent: list text matches paragraph font

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -406,7 +406,8 @@
     font-style: normal;
 }
 
-p {
+p,
+li {
     font-family: var(--font-paragraph);
 }
 


### PR DESCRIPTION
## Problem

On posts like [an-update-on-my-self-studying](https://btromm.github.io/posts/an-update-on-my-self-studying/), text inside numbered/bulleted lists used a different font than regular body paragraphs.

**Root cause:** The `<body>` font is `--font-body` (Literata, serif). Paragraphs were explicitly overridden to `--font-paragraph` (Source Sans, sans-serif) in `assets/css/custom.css`, but `<li>` text had no override, so it inherited the serif body font. Only the list *marker* had been switched to the paragraph font.

## Fix

Apply `--font-paragraph` to `<li>` as well, so all body text (paragraphs and lists) renders in the same font.

Headings are unaffected — they continue to inherit `--font-body` (Literata) from the body, preserving the intended distinct heading font.

```css
p,
li {
    font-family: var(--font-paragraph);
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDxKkoV52waU12ZAQpHp1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDxKkoV52waU12ZAQpHp1N)_